### PR TITLE
Fix/recordtype response ci state

### DIFF
--- a/model/qti/ResponseDeclaration.php
+++ b/model/qti/ResponseDeclaration.php
@@ -117,8 +117,6 @@ class ResponseDeclaration extends VariableDeclaration implements ContentVariable
         $correctResponses = $this->getCorrectResponses();
         if (is_array($correctResponses)) {
             foreach ($correctResponses as $correctResponseKey => $value) {
-                \common_Logger::d('******* '.print_r($this->getAttribute('cardinality'), true));
-                \common_Logger::d('******* '.print_r($this->getAttribute('cardinality') == 'record', true));
                 //if correct response has cardinality record:
                 if($this->getAttribute('cardinality') == 'record'){
                     $valueData = $value->toArray();

--- a/model/qti/ResponseDeclaration.php
+++ b/model/qti/ResponseDeclaration.php
@@ -91,7 +91,7 @@ class ResponseDeclaration extends VariableDeclaration implements ContentVariable
     protected $simpleFeedbackRules = array();
 
     protected function generateIdentifier($prefix = ''){
-        
+
         if(empty($prefix)){
             $prefix = 'RESPONSE'; //QTI standard default value
         }
@@ -105,7 +105,7 @@ class ResponseDeclaration extends VariableDeclaration implements ContentVariable
         //@todo : clean this please: do not use a class attributes to store childdren's ones.
         unset($data['attributes']['mapping']);
         unset($data['attributes']['areaMapping']);
-        
+
         //prepare the protected data:
         $protectedData = array(
             'mapping' => $this->mapping,
@@ -113,13 +113,22 @@ class ResponseDeclaration extends VariableDeclaration implements ContentVariable
             'howMatch' => $this->howMatch
         );
 
+        $correct = [];
         $correctResponses = $this->getCorrectResponses();
         if (is_array($correctResponses)) {
-            foreach ($correctResponses as $correctResponseKey => $correctResponse) {
-                $correctResponses[$correctResponseKey] = (string) $correctResponse;
+            foreach ($correctResponses as $correctResponseKey => $value) {
+                \common_Logger::d('******* '.print_r($this->getAttribute('cardinality'), true));
+                \common_Logger::d('******* '.print_r($this->getAttribute('cardinality') == 'record', true));
+                //if correct response has cardinality record:
+                if($this->getAttribute('cardinality') == 'record'){
+                    $valueData = $value->toArray();
+                    $correct[$valueData['fieldIdentifier']] = $valueData;
+                }else{
+                    $correct[$correctResponseKey] = (string) $value;
+                }
             }
         }
-        $protectedData['correctResponses'] = $correctResponses;
+        $protectedData['correctResponses'] = $correct;
 
         //add mapping attributes
         $mappingAttributes = array('defaultValue' => $this->mappingDefaultValue);
@@ -129,10 +138,10 @@ class ResponseDeclaration extends VariableDeclaration implements ContentVariable
             $mappingAttributes = array_merge($mappingAttributes, $this->getAttributeValue('areaMapping'));
         }
         $protectedData['mappingAttributes'] = $mappingAttributes;
-        
+
         //add simple feedbacks
         $protectedData['feedbackRules'] = $this->getArraySerializedElementCollection($this->getFeedbackRules(), $filterVariableContent, $filtered);
-        
+
         if($filterVariableContent){
             $filtered[$this->getSerial()] = $protectedData;
         }else{
@@ -166,17 +175,17 @@ class ResponseDeclaration extends VariableDeclaration implements ContentVariable
         $rpTemplate = '';
         switch($this->howMatch){
             case Template::MATCH_CORRECT:{
-                    $rpTemplate = 'match_correct';
-                    break;
-                }
+                $rpTemplate = 'match_correct';
+                break;
+            }
             case Template::MAP_RESPONSE:{
-                    $rpTemplate = 'map_response';
-                    break;
-                }
+                $rpTemplate = 'map_response';
+                break;
+            }
             case Template::MAP_RESPONSE_POINT:{
-                    $rpTemplate = 'map_response_point';
-                    break;
-                }
+                $rpTemplate = 'map_response_point';
+                break;
+            }
         }
         $variables['howMatch'] = $this->howMatch; //the template
         $variables['rpTemplate'] = $rpTemplate; //the template
@@ -277,7 +286,7 @@ class ResponseDeclaration extends VariableDeclaration implements ContentVariable
     /**
      * get the correct response in JSON format. If no correct response defined
      * null.
-     * 
+     *
      * @deprecated now use the new qtism lib for response evaluation
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
@@ -289,14 +298,14 @@ class ResponseDeclaration extends VariableDeclaration implements ContentVariable
             $correctResponses = $this->getCorrectResponses();
             if(count($correctResponses)){
                 $returnValue = taoQTI_models_classes_Matching_VariableFactory::createJSONVariableFromQTIData(
-                                $this->getIdentifier()
-                                , $this->getAttributeValue('cardinality')
-                                , $this->getAttributeValue('baseType')
-                                , $this->correctResponses
+                    $this->getIdentifier()
+                    , $this->getAttributeValue('cardinality')
+                    , $this->getAttributeValue('baseType')
+                    , $this->correctResponses
                 );
             }
         }catch(Exception $e){
-            
+
         }
 
         return $returnValue;
@@ -343,7 +352,7 @@ class ResponseDeclaration extends VariableDeclaration implements ContentVariable
 
     /**
      * get the mapping in JSON format. If no mapping defined return null.
-     *  
+     *
      * @deprecated now use the new qtism lib for response evaluation
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>

--- a/model/qti/Value.php
+++ b/model/qti/Value.php
@@ -28,8 +28,7 @@ namespace oat\taoQtiItem\model\qti;
  * @access public
  * @author Joel Bout, <joel.bout@tudor.lu>
  * @package taoQTI
- * @see http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10073
-
+ * @see http://www.imsglobal.org/question/qtiv2p1/imsqti_infov2p1.html#element10042
  */
 class Value extends Element
 {
@@ -76,5 +75,23 @@ class Value extends Element
     public function getValue()
     {
         return $this->value;
+    }
+
+    /**
+     * Get the array representation of the Qti Element.
+     * Particularly helpful for data transformation, e.g. json
+     * 
+     * @param bool $filterVariableContent
+     * @param array $filtered
+     * @return array
+     */
+    public function toArray($filterVariableContent = false, &$filtered = array())
+    {
+        return [
+            'value' => $this->value,
+            'fieldIdentifier' => (string) $this->getAttribute('fieldIdentifier'),
+            'baseType' => (string) $this->getAttribute('baseType'),
+            'cardinality' => 'single'//cardinality always single for value, put it here to make it compatible with the rule engine
+        ];
     }
 }

--- a/test/samples/xml/qtiv2p1/responseProcessing/custom_record.xml
+++ b/test/samples/xml/qtiv2p1/responseProcessing/custom_record.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assessmentItem
+        xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1"
+        xmlns:xml="http://www.w3.org/XML/1998/namespace"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd "
+        identifier="i1468246257550489" title="Item 16" adaptive="false" timeDependent="false" label="" xml:lang="en-US" toolName="TAO" toolVersion="3.1.0-sprint15">
+    <responseDeclaration identifier="RESPONSE" cardinality="record">
+        <correctResponse>
+            <value fieldIdentifier="fieldA" baseType="string">yes</value>
+            <value fieldIdentifier="fieldB" baseType="integer">2</value>
+        </correctResponse>
+    </responseDeclaration>
+    <outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" />
+    <itemBody>
+        <div class="grid-row">
+            <div class="col-12">
+                QQQ
+            </div>
+        </div>
+    </itemBody>
+    <responseProcessing>
+        <responseCondition>
+            <responseIf>
+                <match>
+                    <fieldValue fieldIdentifier="fieldA">
+                        <variable identifier="RESPONSE"/>
+                    </fieldValue>
+                    <fieldValue fieldIdentifier="fieldA">
+                        <correct identifier="RESPONSE"/>
+                    </fieldValue>
+                </match>
+                <setOutcomeValue identifier="SCORE">
+                    <baseValue baseType="float">2.0</baseValue>
+                </setOutcomeValue>
+            </responseIf>
+            <responseElse>
+                <setOutcomeValue identifier="SCORE">
+                    <baseValue baseType="float">-1.0</baseValue>
+                </setOutcomeValue>
+            </responseElse>
+        </responseCondition>
+    </responseProcessing>
+</assessmentItem>

--- a/views/js/qtiCommonRenderer/renderers/interactions/PortableCustomInteraction.js
+++ b/views/js/qtiCommonRenderer/renderers/interactions/PortableCustomInteraction.js
@@ -178,7 +178,7 @@ define([
      * @param {Object} interaction
      * @param {Object} serializedState - json format
      */
-    var setSerializedState = function(interaction, serializedState){
+    var setState = function(interaction, serializedState){
         _getPci(interaction).setSerializedState(serializedState);
     };
 
@@ -189,7 +189,7 @@ define([
      * @param {Object} interaction
      * @returns {Object} json format
      */
-    var getSerializedState = function(interaction){
+    var getState = function(interaction){
         return _getPci(interaction).getSerializedState();
     };
 
@@ -212,7 +212,7 @@ define([
         getResponse : getResponse,
         resetResponse : resetResponse,
         destroy : destroy,
-        getSerializedState : getSerializedState,
-        setSerializedState : setSerializedState
+        getState : getState,
+        setState : setState
     };
 });

--- a/views/js/test/samples/json/customrp/custom_record.json
+++ b/views/js/test/samples/json/customrp/custom_record.json
@@ -1,0 +1,175 @@
+{
+    "type": "qti",
+    "data": {
+        "identifier": "i1468246257550489",
+        "serial": "item_5784ed91a8f8f520320995",
+        "qtiClass": "assessmentItem",
+        "attributes": {
+            "identifier": "i1468246257550489",
+            "title": "Item 16",
+            "label": "",
+            "xml:lang": "en-US",
+            "adaptive": false,
+            "timeDependent": false,
+            "toolName": "TAO",
+            "toolVersion": "3.1.0-sprint15",
+            "class": ""
+        },
+        "body": {
+            "serial": "container_containeritembody_5784ed91a8f74666402209",
+            "body": "\n        <div class=\"grid-row\">\n            <div class=\"col-12\">\n                QQQ\n            <\/div>\n        <\/div>\n    ",
+            "elements": {},
+            "debug": {
+                "relatedItem": "item_5784ed91a8f8f520320995"
+            }
+        },
+        "debug": {
+            "relatedItem": "item_5784ed91a8f8f520320995"
+        },
+        "namespaces": {
+            "": "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p1",
+            "xml": "http:\/\/www.w3.org\/XML\/1998\/namespace",
+            "xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance"
+        },
+        "schemaLocations": {
+            "http:\/\/www.imsglobal.org\/xsd\/imsqti_v2p1": "http:\/\/www.imsglobal.org\/xsd\/qti\/qtiv2p1\/imsqti_v2p1.xsd"
+        },
+        "stylesheets": {},
+        "outcomes": {
+            "outcomedeclaration_5784ed91ad60f883015879": {
+                "identifier": "SCORE",
+                "serial": "outcomedeclaration_5784ed91ad60f883015879",
+                "qtiClass": "outcomeDeclaration",
+                "attributes": {
+                    "identifier": "SCORE",
+                    "cardinality": "single",
+                    "baseType": "float"
+                },
+                "debug": {
+                    "relatedItem": "item_5784ed91a8f8f520320995"
+                },
+                "defaultValue": null
+            }
+        },
+        "responses": {
+            "responsedeclaration_5784ed91ac168519849035": {
+                "identifier": "RESPONSE",
+                "serial": "responsedeclaration_5784ed91ac168519849035",
+                "qtiClass": "responseDeclaration",
+                "attributes": {
+                    "identifier": "RESPONSE",
+                    "cardinality": "record"
+                },
+                "debug": {
+                    "relatedItem": "item_5784ed91a8f8f520320995"
+                },
+                "mapping": [],
+                "areaMapping": [],
+                "howMatch": null,
+                "correctResponses": {
+                    "fieldA": {
+                        "value": "yes",
+                        "fieldIdentifier": "fieldA",
+                        "cardinality": "single",
+                        "baseType": "string"
+                    },
+                    "fieldB": {
+                        "value": "2",
+                        "fieldIdentifier": "fieldB",
+                        "baseType": "integer"
+                    }
+                },
+                "mappingAttributes": {
+                    "defaultValue": 0
+                },
+                "feedbackRules": {}
+            }
+        },
+        "feedbacks": {},
+        "responseProcessing": {
+            "serial": "response_custom_5784ed91afefe440941847",
+            "qtiClass": "responseProcessing",
+            "attributes": [],
+            "debug": {
+                "relatedItem": ""
+            },
+            "processingType": "custom",
+            "data": "<responseProcessing>\n        <responseCondition>\n            <responseIf>\n                <match>\n                    <fieldValue fieldIdentifier=\"fieldA\">\n                        <variable identifier=\"RESPONSE\"\/>\n                    <\/fieldValue>\n                    <fieldValue fieldIdentifier=\"fieldA\">\n                        <correct identifier=\"RESPONSE\"\/>\n                    <\/fieldValue>\n                <\/match>\n                <setOutcomeValue identifier=\"SCORE\">\n                    <baseValue baseType=\"float\">2.0<\/baseValue>\n                <\/setOutcomeValue>\n            <\/responseIf>\n            <responseElse>\n                <setOutcomeValue identifier=\"SCORE\">\n                    <baseValue baseType=\"float\">-1.0<\/baseValue>\n                <\/setOutcomeValue>\n            <\/responseElse>\n        <\/responseCondition>\n    <\/responseProcessing>",
+            "responseRules": [
+                {
+                    "qtiClass": "responseCondition",
+                    "responseIf": {
+                        "qtiClass": "responseIf",
+                        "expression": {
+                            "qtiClass": "match",
+                            "expressions": [
+                                {
+                                    "qtiClass": "fieldValue",
+                                    "attributes": {
+                                        "fieldIdentifier": "fieldA"
+                                    },
+                                    "expressions": [
+                                        {
+                                            "qtiClass": "variable",
+                                            "attributes": {
+                                                "identifier": "RESPONSE"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "qtiClass": "fieldValue",
+                                    "attributes": {
+                                        "fieldIdentifier": "fieldA"
+                                    },
+                                    "expressions": [
+                                        {
+                                            "qtiClass": "correct",
+                                            "attributes": {
+                                                "identifier": "RESPONSE"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "responseRules": [
+                            {
+                                "qtiClass": "setOutcomeValue",
+                                "attributes": {
+                                    "identifier": "SCORE"
+                                },
+                                "expression": {
+                                    "qtiClass": "baseValue",
+                                    "attributes": {
+                                        "baseType": "float"
+                                    },
+                                    "value": "2.0"
+                                }
+                            }
+                        ]
+                    },
+                    "responseElse": {
+                        "qtiClass": "responseElse",
+                        "responseRules": [
+                            {
+                                "qtiClass": "setOutcomeValue",
+                                "attributes": {
+                                    "identifier": "SCORE"
+                                },
+                                "expression": {
+                                    "qtiClass": "baseValue",
+                                    "attributes": {
+                                        "baseType": "float"
+                                    },
+                                    "value": "-1.0"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "apipAccessibility": ""
+    }
+}

--- a/views/js/test/scoring/provider/test.js
+++ b/views/js/test/scoring/provider/test.js
@@ -14,19 +14,21 @@ define([
     'json!taoQtiItem/test/samples/json/es6.json',
     'json!taoQtiItem/test/samples/json/pluto.json',
     'json!taoQtiItem/test/samples/json/customrp/andAnd.json',
+    'json!taoQtiItem/test/samples/json/customrp/custom_record.json'
 ], function(_, scorer, qtiScoringProvider,
-        singleCorrectData,
-        multipleCorrectData,
-        multipleMapData,
-        singleMapPointData,
-        customChoiceMultipleData,
-        customTextEntryNumericData,
-        customChoiceMultipleData2,
-        customChoiceSingleData,
-        orderData,
-        multipleResponseCorrectData,
-        embedConditionsData,
-        andAndData
+            singleCorrectData,
+            multipleCorrectData,
+            multipleMapData,
+            singleMapPointData,
+            customChoiceMultipleData,
+            customTextEntryNumericData,
+            customChoiceMultipleData2,
+            customChoiceSingleData,
+            orderData,
+            multipleResponseCorrectData,
+            embedConditionsData,
+            andAndData,
+            customRecordData
 ){
     'use strict';
 
@@ -419,6 +421,18 @@ define([
         },
         outcomes : {
             SCORE : { base : { 'float' : 1 } }
+        }
+    }, {
+        title   : 'custom record',
+        item    : customRecordData.data,
+        resp    : {
+            RESPONSE   : { record : [{
+                name : 'fieldA',
+                base : {string : 'yes'}
+            }] }
+        },
+        outcomes : {
+            SCORE : { base : { 'float' : 2 } }
         }
     }];
 


### PR DESCRIPTION
This is but the same commits as https://github.com/oat-parcc/extension-tao-itemqti/pull/10 and https://github.com/oat-parcc/extension-tao-itemqti/pull/11

Sorry, I should have created PR to develop directly because oat-parcc/extension-tao-itemqti is a fork and not an old tag of oat-sa/extension-tao-itemqti.

The release-2.14.2 branch is reserved for merging into master at the end of this sprint.

After merging this PR, we should remove the misleading release-2.14.2 branch https://github.com/oat-parcc/extension-tao-itemqti/tree/release-2.14.2

(no worry, the backport to the upstream is still valid, since it was into oat-sa develop)
